### PR TITLE
Remove `Result<T>` type in favour of `Swift.Result<T, Error>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [Unreleased] 
+- Remove Result<T> type alias to Swift.Result<T, Error> (#12)
 
 ## 1.2.1 - 2020-11-07
 

--- a/Sources/CoreDataMind/ContextObserver.swift
+++ b/Sources/CoreDataMind/ContextObserver.swift
@@ -12,7 +12,7 @@ public final class ContextObserver<T: NSManagedObject> {
 
 	fileprivate let context: NSManagedObjectContext
 	fileprivate let persistentStoreCoordinator: NSPersistentStoreCoordinator?
-	fileprivate let masterPredicate: NSPredicate
+	fileprivate let mainPredicate: NSPredicate
 	fileprivate let didChange: ChangedEvent
 	fileprivate let keys = [NSInsertedObjectsKey, NSDeletedObjectsKey, NSUpdatedObjectsKey]
 	fileprivate var enabled = false
@@ -26,9 +26,9 @@ public final class ContextObserver<T: NSManagedObject> {
 
 		let entityPredicate = NSPredicate(format: "entity = %@", entity)
 		if let predicate = predicate {
-			masterPredicate = entityPredicate + predicate
+			mainPredicate = entityPredicate + predicate
 		} else {
-			masterPredicate = entityPredicate
+			mainPredicate = entityPredicate
 		}
 
 		didChange = onChange
@@ -65,7 +65,7 @@ public final class ContextObserver<T: NSManagedObject> {
 
 		var result = [String: [Entity]]()
 		keys.forEach {
-			if let set = filteredSetForKey(userInfo, key: $0, predicate: masterPredicate) {
+			if let set = filteredSetForKey(userInfo, key: $0, predicate: mainPredicate) {
 				result[$0] = set
 			}
 		}

--- a/Sources/CoreMind/Result.swift
+++ b/Sources/CoreMind/Result.swift
@@ -8,18 +8,9 @@ import Foundation
 /// Conform String to Error in order to use it for simpler error throwing
 extension String: Error {}
 
-/// The Result type either represents a success - which has an associated value
-/// representing the successful result - or a falure - whith an associated error.
-/// See http://alisoftware.github.io/swift/async/error/2016/02/06/async-errors/
-///
-/// - success: represents the successful result
-/// - failure: represents a failure with an associated error
-// @available(*, deprecated, message: "Please use `Swift.Result`")
-public typealias Result<T> = Swift.Result<T, Error>
-
 // MARK: - Non throwing values
 
-public extension Swift.Result {
+public extension Result {
 	/// Unwraps a Result without throwing
 	///
 	/// - Returns: nil in case of an error, the value otherwise

--- a/Sources/CoreMindTests/DeviceInfoTests.swift
+++ b/Sources/CoreMindTests/DeviceInfoTests.swift
@@ -15,7 +15,11 @@ final class DeviceInfoTests: XCTestCase {
 	}
 
 	func testModel() {
-		XCTAssertEqual(sut.model, "x86_64")
+        #if arch(arm64)
+		XCTAssertEqual(sut.model, "arm64")
+        #else
+        XCTAssertEqual(sut.model, "x86_64")
+        #endif
 	}
 
 	func testOs() {


### PR DESCRIPTION
This PR removes the `Result<T>` type alias kept around to provide backward compatibility. This will break all project that use `Result` without an explicit `Error` in the type definition. 

You can quick fix this by adding `public typealias Result<T> = Swift.Result<T, Error>` to your project. 
The recommended solution is to replace the obsolete type.